### PR TITLE
Fix MacOS release

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -31,7 +31,6 @@ jobs:
           python-version: '3.11.6' 
       - name: Utils
         run: |
-          brew install graphicsmagick imagemagick
           npm -g install appdmg
       - name: Build
         run: cargo build --release --features=bundled

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -22,9 +22,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: Homebrew setup
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
       - name: Setup Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
MacOS release was failing because brew is trying to install packages that are already present on the system. I found that
 1. graphicsmagick is a fork of imagemagick so we don't need both
 2. furthermore nowhere in our code we use imagemagick or graphicsmagick. This make installing them unnecessary.
 3. As they are the only packages we install from brew we don't need brew either.