### PR TITLE
Sign the setup and uninstaller using ISCC

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -29,7 +29,7 @@ jobs:
           dest: stremio-service-windows.zip
       - name: Installer
         run: |
-          & 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe' '/Sstremiosign=$qC:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe$q sign /f $q'+(Get-Location).Path+'\resources\certificates\smartcode-20211118-20241118.pfx$q /p ${{ secrets.WIN_CERT_PASSWORD }} /v $f' 'setup\StremioService.iss'
+          & 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe' '/Sstremiosign=$qC:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe$q sign /f $q.\resources\certificates\smartcode-20211118-20241118.pfx$q /p ${{ secrets.WIN_CERT_PASSWORD }} /v $f' 'setup\StremioService.iss'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -29,7 +29,7 @@ jobs:
           dest: stremio-service-windows.zip
       - name: Installer
         run: |
-          & 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe' '/Sstremiosign=$qC:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe$q sign /f $qresources\certificates\smartcode-20211118-20241118.pfx$q /p ${{ secrets.WIN_CERT_PASSWORD }} /v $f' 'setup\StremioService.iss'
+          & 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe' '/Sstremiosign=$qC:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe$q sign /f $q..\resources\certificates\smartcode-20211118-20241118.pfx$q /p ${{ secrets.WIN_CERT_PASSWORD }} /v $f' 'setup\StremioService.iss'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -29,7 +29,7 @@ jobs:
           dest: stremio-service-windows.zip
       - name: Installer
         run: |
-          & 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe' '/Sstremiosign=$qC:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe$q sign /f $q.\resources\certificates\smartcode-20211118-20241118.pfx$q /p ${{ secrets.WIN_CERT_PASSWORD }} /v $f' 'setup\StremioService.iss'
+          & 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe' '/Sstremiosign=$qC:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe$q sign /f $q${{ github.workspace }}\resources\certificates\smartcode-20211118-20241118.pfx$q /p ${{ secrets.WIN_CERT_PASSWORD }} /v $f' 'setup\StremioService.iss'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -29,7 +29,7 @@ jobs:
           dest: stremio-service-windows.zip
       - name: Installer
         run: |
-          & 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe' '/Sstremiosign=$qC:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe$q sign /f $q..\resources\certificates\smartcode-20211118-20241118.pfx$q /p ${{ secrets.WIN_CERT_PASSWORD }} /v $f' 'setup\StremioService.iss'
+          & 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe' '/Sstremiosign=$qC:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe$q sign /f $q'+(Get-Location).Path+'\resources\certificates\smartcode-20211118-20241118.pfx$q /p ${{ secrets.WIN_CERT_PASSWORD }} /v $f' 'setup\StremioService.iss'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -29,11 +29,7 @@ jobs:
           dest: stremio-service-windows.zip
       - name: Installer
         run: |
-          & 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe' 'setup\StremioService.iss'
-
-      - name: Sign Installer
-        run: |
-          & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe' sign /f "resources\certificates\smartcode-20211118-20241118.pfx" /p ${{ secrets.WIN_CERT_PASSWORD }} /v "StremioServiceSetup.exe"
+          & 'C:\Program Files (x86)\Inno Setup 6\ISCC.exe' '/Sstremiosign=$qC:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe$q sign /f $qresources\certificates\smartcode-20211118-20241118.pfx$q /p ${{ secrets.WIN_CERT_PASSWORD }} /v $f' 'setup\StremioService.iss'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/setup/StremioService.iss
+++ b/setup/StremioService.iss
@@ -47,6 +47,8 @@ WizardImageFile={#SourcePath}\windows-installer.bmp
 WizardSmallImageFile={#SourcePath}\windows-installer-header.bmp
 SetupIconFile={#SourcePath}..\resources\service.ico
 UninstallDisplayIcon={app}\{#MyAppExeName},0
+SignTool=stremiosign
+SignedUninstaller=yes
 
 [Code]
 function ShouldSkipPage(PageID: Integer): Boolean;


### PR DESCRIPTION
Passing the signtool command line to ISCC enables it to sign the installer and uninstaller.