### PR TITLE
fix: quit on windows

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -161,11 +161,11 @@ impl Application {
                         open_stremio_web(None);
                     }
                     if menu_id == quit_item_id {
-                        system_tray.take();
                         *control_flow = ControlFlow::Exit;
                     }
                 }
                 Event::LoopDestroyed => {
+                    system_tray.take();
                     if let Err(err) = server.stop() {
                         error!("{err}")
                     }


### PR DESCRIPTION
Resolves issue #81

When the system tray is dropped from within the MenuEvent on Windows, the LoopDestroyed event is never emitted resulting in the system tray icon being removed while both processes continue running.

This just moves `system_tray.take();` out of the MenuEvent allowing the service to exit properly on Windows OS.