### PR TITLE
fix: only try to get runtime dir on linux

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -39,9 +39,17 @@ impl Config {
     pub fn new(args: Args) -> Result<Self, Error> {
         let home_dir = dirs::home_dir().context("Failed to get home dir")?;
         let cache_dir = dirs::cache_dir().context("Failed to get cache dir")?;
-        let runtime_dir = dirs::runtime_dir().context("Failed to get runtime dir")?;
 
-        let tray_icon = runtime_dir.join("stremio-service");
+        let tray_icon = {
+            #[cfg(target_os = "linux")]
+            {
+                let runtime_dir = dirs::runtime_dir().context("Failed to get runtime dir")?;
+                runtime_dir.join("stremio-service")
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            PathBuf::new()
+        };
 
         let lockfile = cache_dir.join("lock");
 


### PR DESCRIPTION
dirs::runtime_dir() always returns None on Windows and Mac OS preventing the service from starting.

There might be a better way to resolve this, but since config.tray_icon is only used for TrayIconBuilder's with_temp_dir_path method (which drops the PathBuf reference when called on Windows and Mac OS), config.tray_icon can just be set to an empty PathBuf for non-Linux platforms.