### PR TITLE
fix: include resources when building cross-platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,17 +604,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +728,20 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embed-resource"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a075fc573c64510038d7ee9abc7990635863992f83ebc52c8b433b8411a02e"
+dependencies = [
+ "cc",
+ "memchr",
+ "rustc_version",
+ "toml 0.9.5",
+ "vswhom",
+ "winreg 0.55.0",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1498,16 +1501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ico"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3804960be0bb5e4edb1e1ad67afd321a9ecfd875c3e65c099468fd2717d7cae"
-dependencies = [
- "byteorder",
- "png",
-]
-
-[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,15 +1894,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "manual-serializer"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02dee11e3506095a84dddc0ecd8c9ff61f6611e6353ba6f9bb85c63144ae088"
-dependencies = [
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2647,7 +2631,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -2916,13 +2900,13 @@ dependencies = [
  "chrono",
  "clap",
  "dirs 5.0.1",
+ "embed-resource",
  "env_logger",
  "flate2",
  "fruitbasket",
  "fslock",
  "futures-util",
  "hex",
- "ico",
  "image",
  "log",
  "once_cell",
@@ -2941,8 +2925,6 @@ dependencies = [
  "url",
  "urlencoding",
  "walkdir",
- "winres",
- "winres-edit",
  "xz",
  "zip-extract",
 ]
@@ -2966,7 +2948,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
  "unicode-ident",
 ]
 
@@ -3065,7 +3046,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.60.0",
+ "windows",
  "windows-core 0.60.1",
  "windows-version",
  "x11-dl",
@@ -3243,15 +3224,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -3497,6 +3469,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vswhom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
+dependencies = [
+ "libc",
+ "vswhom-sys",
+]
+
+[[package]]
+name = "vswhom-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,21 +3658,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
 
 [[package]]
 name = "windows"
@@ -4044,24 +4021,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "winres"
-version = "0.1.12"
+name = "winreg"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
- "toml 0.5.11",
-]
-
-[[package]]
-name = "winres-edit"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded2b41cae4b547961adf48f471d74abbe02c6ba281cedfe93d92bf9d5c66383"
-dependencies = [
- "derivative",
- "manual-serializer",
- "thiserror 1.0.69",
- "windows 0.43.0",
+ "cfg-if 1.0.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,12 +78,6 @@ ashpd = "0.11"
 # MacOS Apple Events handling
 fruitbasket = "0.10"
 
-[target.'cfg(target_os = "windows")'.build-dependencies]
-winres = "0.1"
-winres-edit = "0.1.0"
-chrono = "0.4"
-ico = "0.3.0"
-
 [build-dependencies]
 bytes = "1.0"
 flate2 = "1.0"
@@ -91,6 +85,7 @@ reqwest = { version = "0.11", features = ["blocking"] }
 tar = "0.4"
 xz = "0.1.0"
 zip-extract = "0.1"
+embed-resource = "3.0"
 
 url = { version = "2.3" }
 once_cell = "1.16"

--- a/resources/stremio-runtime.rc
+++ b/resources/stremio-runtime.rc
@@ -1,0 +1,32 @@
+// Icon resource
+1 ICON "service.ico"
+
+// Version information
+1 VERSIONINFO
+FILEVERSION 0,1,15,0
+PRODUCTVERSION 0,1,15,0
+FILEFLAGSMASK 0x3fL
+FILEFLAGS 0x0L
+FILEOS 0x40004L
+FILETYPE 0x1L
+FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "Stremio"
+            VALUE "FileDescription", "Stremio Service"
+            VALUE "FileVersion", "0.1.15.0"
+            VALUE "InternalName", "stremio-runtime"
+            VALUE "LegalCopyright", "Copyright \251 2026 Smart Code OOD"
+            VALUE "OriginalFilename", "stremio-runtime.exe"
+            VALUE "ProductName", "Stremio Runtime"
+            VALUE "ProductVersion", "0.1.15.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
Some changes to build.rs to include the icon, version info, etc... when building cross-platform for windows.
Unfortunately, this does add another file with year and version info that will need to be bumped occasionally.